### PR TITLE
breadcrumb logic changed a bit - players can't overwrite the opp now

### DIFF
--- a/assets/js/board.js
+++ b/assets/js/board.js
@@ -136,13 +136,8 @@ var Board = {
             }
         }
 
-        if (Board.myX == Board.oppX && Board.myY == Board.oppY) {
-            Board.history[Board.myX][Board.myY] = 3;
-        } else {
-            Board.history[Board.myX][Board.myY] = 1;
-            Board.history[Board.oppX][Board.oppY] = 2;
-        }
-
+        Board.history[Board.myX][Board.myY] |= 1;
+        Board.history[Board.oppX][Board.oppY] |= 2;
 
     },
     noMoreItems: function() {


### PR DESCRIPTION
Reworked breadcrumbs logic like we talked about earlier.

Player 1 visit = teal
Player 2 visit = purple
if both visit = gray

Players don't overwrite the opponent's marks, only shift to gray.
