### PR TITLE
Merged old largeboard branch - added select field for small, medium, large

### DIFF
--- a/assets/js/board.js
+++ b/assets/js/board.js
@@ -1,12 +1,44 @@
 var Board = {
     init: function(boardNumber) {
         var fullBoard;
+        var min_size = 5;
+        var max_size = 15;
+
+        if (typeof(localStorage) != 'undefined' ) {
+            $("#select_largeboard").show();
+            var val = null;
+            try {
+                val = localStorage.getItem("board");
+            } catch (e) {
+            }
+
+            if (val !== null) {
+                var spl = val.split(';');
+
+                Board.min_size = parseInt(spl[0],10);
+                Board.max_size = parseInt(spl[1],10);
+
+                $("#select_largeboard option").each(function(opt) {
+                    if ($(this).val() == val) {
+                        console.log($(this).val());
+                        $(this).prop('selected', true);
+                    }
+                });
+            }
+
+
+
+            $('#largeboard_dim').change(function(evt) {
+                localStorage.setItem("board", evt.srcElement.value);
+                location.reload();
+            });
+        }
 
         Board.initRandom(boardNumber);
 
         // initialize board
-        HEIGHT = Math.min(Math.floor(Board.random() * 11) + 5, 15);
-        WIDTH = Math.min(Math.floor(Board.random() * 11) + 5, 15);
+        HEIGHT = Math.min(Math.floor(Board.random() * (Board.max_size-Board.min_size+1)) + Board.min_size, Board.max_size);
+        WIDTH = Math.min(Math.floor(Board.random() * (Board.max_size-Board.min_size+1)) + Board.min_size, Board.max_size);
 
         Board.board = new Array(WIDTH);
 

--- a/assets/js/board.js
+++ b/assets/js/board.js
@@ -1,8 +1,9 @@
 var Board = {
     init: function(boardNumber) {
         var fullBoard;
-        var min_size = 5;
-        var max_size = 15;
+        Board.min_size = 5;
+        Board.max_size = 15;
+        Board.move_num = 0;
 
         if (typeof(localStorage) != 'undefined' ) {
             $("#select_largeboard").show();
@@ -20,7 +21,6 @@ var Board = {
 
                 $("#select_largeboard option").each(function(opt) {
                     if ($(this).val() == val) {
-                        console.log($(this).val());
                         $(this).prop('selected', true);
                     }
                 });
@@ -111,7 +111,11 @@ var Board = {
         // SimpleBot currently doesn't need any sort of init, but if it did, it'd be called here too
     },
     processMove: function() {
+        Board.move_num++;
+        var move_start = new Date().getTime();
         var myMove = make_move();
+        var elapsed = ((new Date().getTime() - move_start) / 1000).toFixed(2);
+        console.log("["+Board.move_num+"] elapsed time: "+elapsed+"s");
         var simpleBotMove = SimpleBot.makeMove();
         if ((Board.myX == Board.oppX) && (Board.myY == Board.oppY) && (myMove == TAKE) && (simpleBotMove == TAKE) && Board.board[Board.myX][Board.myY] > 0) {
             Board.myBotCollected[Board.board[Board.myX][Board.myY]-1] = Board.myBotCollected[Board.board[Board.myX][Board.myY]-1] + 0.5;

--- a/game.html
+++ b/game.html
@@ -21,6 +21,15 @@
 <span class=""><label><input type="checkbox" id="check_breadcrumbs"/> Show breadcrumbs</label></span>
 <br><br>
 <label>Board Number: </label><input type="text" id="board_number"/><button id="set_board">Set</button>
+<br>
+<span id="select_largeboard" style="display:none;">
+    <label>Board Size Range: </label>
+    <select id="largeboard_dim">
+        <option value="5;15">Small (5-15)</option>
+        <option value="10;20">Medium (10-20)</option>
+        <option value="15;40">Large (15-40)</option>
+    </select>
+</span>
 </div>
 </body>
 </html>


### PR DESCRIPTION
New set of patches to add large board options. Instead of offering just "large" or not, I added a drop-down to select small, medium, or large boards.

Small = 5-15
Medium = 10-20
Large = 15-40

The settings are persistent with local storage, and works with set board numbers. Although, with board numbers small #1 != medium #1 != large #1.

The other option would be to add a drop down for both min and max values. I thought having set small, medium, and large ranges was the better option. But it really depends on how much you want to expand your game.
